### PR TITLE
add-url-access-note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,8 @@ These slides correspond to a talk about instrumentation at scale. Distributed sy
 
 With `statsd` and `datadog` instrumentation becomes a first class citizen. As the engineer on a system, you can instrument out a "success" and a "failure" story for different components. Metrics, and subsequently, graphs and dashboards of these metrics allow a system to be monitored, debugged and maintained from a birds eye view. Dashboards tend to tell us the _real_ story and give us the insights that we really care about.
 
+https://buzzfeed.datadoghq.com/
+<br/>Email [sysops](mailto:sysops@buzzfeed.com) for an invite.
+
 The slides can be found [here](https://go-talks.appspot.com/github.com/jonmorehouse/instrumentation-talk/slides_3.slide)
 


### PR DESCRIPTION
adding datadog url and note to email sys ops for an invite
